### PR TITLE
WIP: support `navigator.clipboard` text methods on WebKit

### DIFF
--- a/docs/guide/browser/index.md
+++ b/docs/guide/browser/index.md
@@ -592,6 +592,23 @@ When using Vitest Browser, it's important to note that thread blocking dialogs l
 
 In such situations, Vitest provides default mocks with default returned values for these APIs. This ensures that if the user accidentally uses synchronous popup web APIs, the execution would not hang. However, it's still recommended for the user to mock these web APIs for a better experience. Read more in [Mocking](/guide/mocking).
 
+### Clipboard Access
+
+Test code runs as regular page scripts, so `navigator.clipboard` follows the browser's normal security rules. When using the playwright provider:
+
+- Chromium rejects clipboard access unless the `clipboard-read` and `clipboard-write` permissions are granted through the provider's [`contextOptions`](/config/browser/playwright#contextoptions):
+
+```ts
+playwright({
+  contextOptions: {
+    permissions: ['clipboard-read', 'clipboard-write'],
+  },
+})
+```
+
+- Firefox allows clipboard access without any configuration.
+- WebKit only allows page scripts to access the clipboard while handling a real user gesture, and granted permissions do not lift that requirement. Vitest works around this by routing `navigator.clipboard.readText` and `navigator.clipboard.writeText` through the provider, so they work without any configuration. The `read()` and `write()` methods are not bridged and still require a user gesture.
+
 ### Spying on Module Exports
 
 Browser Mode uses the browser's native ESM support to serve modules. The module namespace object is sealed and can't be reconfigured, unlike in Node.js tests where Vitest can patch the Module Runner. This means you can't call `vi.spyOn` on an imported object:

--- a/packages/browser-playwright/src/commands/clipboard.ts
+++ b/packages/browser-playwright/src/commands/clipboard.ts
@@ -1,0 +1,37 @@
+import type { BrowserCommand, BrowserCommandContext } from 'vitest/node'
+
+// WebKit only lets page scripts access the clipboard while handling a real
+// user gesture; the `clipboard-read` permission alone does not lift that
+// requirement. Scripts evaluated through the Playwright protocol run with an
+// emulated user gesture, so the WebKit tester bridges `navigator.clipboard`
+// text methods to these commands. They evaluate on the orchestrator page
+// instead of the tester frame because the frame's `navigator.clipboard` is
+// patched to call them.
+// See https://github.com/vitest-dev/vitest/issues/10623
+
+const grantedContexts = new WeakSet<object>()
+
+async function grantClipboardPermissions(context: BrowserCommandContext): Promise<void> {
+  const browserContext = context.context
+  if (grantedContexts.has(browserContext)) {
+    return
+  }
+  grantedContexts.add(browserContext)
+  try {
+    await browserContext.grantPermissions(['clipboard-read'])
+  }
+  catch {
+    // not every browser supports the permission; the evaluation below can
+    // still succeed without it
+  }
+}
+
+export const clipboardReadText: BrowserCommand<[]> = async (context) => {
+  await grantClipboardPermissions(context)
+  return context.page.evaluate(() => navigator.clipboard.readText())
+}
+
+export const clipboardWriteText: BrowserCommand<[text: string]> = async (context, text) => {
+  await grantClipboardPermissions(context)
+  await context.page.evaluate(text => navigator.clipboard.writeText(text), text)
+}

--- a/packages/browser-playwright/src/commands/index.ts
+++ b/packages/browser-playwright/src/commands/index.ts
@@ -1,5 +1,6 @@
 import { clear } from './clear'
 import { click, dblClick, tripleClick } from './click'
+import { clipboardReadText, clipboardWriteText } from './clipboard'
 import { dragAndDrop } from './dragAndDrop'
 import { fill } from './fill'
 import { hover } from './hover'
@@ -34,6 +35,8 @@ export default {
   __vitest_fill: fill as typeof fill,
   __vitest_tab: tab as typeof tab,
   __vitest_keyboard: keyboard as typeof keyboard,
+  __vitest_clipboardReadText: clipboardReadText as typeof clipboardReadText,
+  __vitest_clipboardWriteText: clipboardWriteText as typeof clipboardWriteText,
   __vitest_selectOptions: selectOptions as typeof selectOptions,
   __vitest_dragAndDrop: dragAndDrop as typeof dragAndDrop,
   __vitest_hover: hover as typeof hover,

--- a/packages/browser/src/client/tester/clipboard.ts
+++ b/packages/browser/src/client/tester/clipboard.ts
@@ -1,0 +1,28 @@
+import { getBrowserState } from '../utils'
+
+// WebKit requires a real user gesture for `navigator.clipboard` calls made by
+// page scripts, even when the `clipboard-read` permission is granted, while
+// scripts evaluated through the Playwright protocol run with an emulated user
+// gesture. Route the text methods through the provider so they work the same
+// way they do in other browsers.
+// See https://github.com/vitest-dev/vitest/issues/10623
+export function setupClipboardBridge(): void {
+  const clipboard = navigator.clipboard
+  // clipboard is only available in secure contexts
+  if (!clipboard) {
+    return
+  }
+  const commands = getBrowserState().commands
+  clipboard.readText = () =>
+    commands.triggerCommand<string>(
+      '__vitest_clipboardReadText',
+      [],
+      new Error('readText'),
+    )
+  clipboard.writeText = (text: string) =>
+    commands.triggerCommand<void>(
+      '__vitest_clipboardWriteText',
+      [String(text)],
+      new Error('writeText'),
+    )
+}

--- a/packages/browser/src/client/tester/tester.ts
+++ b/packages/browser/src/client/tester/tester.ts
@@ -13,6 +13,7 @@ import {
 } from 'vitest/internal/browser'
 import { Traces } from 'vitest/internal/traces'
 import { getBrowserState, getConfig, getWorkerState, moduleRunner } from '../utils'
+import { setupClipboardBridge } from './clipboard'
 import { setupDialogsSpy } from './dialog'
 import { setupConsoleLogSpy } from './logger'
 import { VitestBrowserClientMocker } from './mocker'
@@ -176,6 +177,10 @@ async function prepareTestEnvironment(options: PrepareOptions) {
     setupConsoleLogSpy()
   }
   setupDialogsSpy()
+
+  if (server.provider === 'playwright' && config.browser.name === 'webkit') {
+    setupClipboardBridge()
+  }
 
   const runner = await initiateRunner(state, mocker, config)
   getBrowserState().runner = runner

--- a/test/browser/fixtures/user-event/clipboard-text.test.ts
+++ b/test/browser/fixtures/user-event/clipboard-text.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest';
+import { server } from 'vitest/browser';
+
+// webkit is the only browser where `navigator.clipboard` works without extra
+// configuration: vitest bridges the text methods through the playwright
+// provider there; chromium needs `clipboard-read`/`clipboard-write`
+// permissions granted in `contextOptions`
+test.runIf(server.provider === 'playwright' && server.config.browser.name === 'webkit')(
+  'clipboard text round-trip without a user gesture',
+  async () => {
+    await navigator.clipboard.writeText('vitest clipboard text');
+    await expect(navigator.clipboard.readText()).resolves.toBe('vitest clipboard text');
+  },
+);

--- a/test/browser/specs/runner.test.ts
+++ b/test/browser/specs/runner.test.ts
@@ -354,6 +354,9 @@ test('user-event', async () => {
     expect(stdout).toReportPassedTest('cleanup2.test.ts', browser)
     expect(stdout).toReportPassedTest('keyboard.test.ts', browser)
     expect(stdout).toReportPassedTest('clipboard.test.ts', browser)
+    if (provider.name === 'playwright' && browser === 'webkit') {
+      expect(stdout).toReportPassedTest('clipboard-text.test.ts', browser)
+    }
   })
 })
 


### PR DESCRIPTION
Not ready for review. 

WebKit only lets page scripts touch the clipboard while handling a real user gesture (granted permissions do not lift that requirement, they only work for scripts evaluated through the Playwright protocol, which run with an emulated user gesture), so this bridges `navigator.clipboard.readText`/`writeText` in the WebKit tester through the playwright provider.  